### PR TITLE
[sieve] fix backward compatibility for sieve index extension

### DIFF
--- a/doc/specs.html
+++ b/doc/specs.html
@@ -184,6 +184,8 @@ draft-murchison-lmtp-ignorequota</A></TD>
 <TD>Sieve Email Filtering: Relational Extension</TD></TR>
 <TR><TD><A HREF="http://www.ietf.org/rfc/rfc5233.txt">RFC 5233</A></TD>
 <TD>Sieve Email Filtering: Subaddress Extension</TD></TR>
+<TR><TD><A HREF="http://www.ietf.org/rfc/rfc5260.txt">RFC 5260</A></TD>
+<TD>Sieve Email Filtering: Date and Index Extensions</TD></TR>
 <TR><TD><A HREF="http://www.ietf.org/rfc/rfc5173.txt">RFC 5173</A></TD>
 <TD>Sieve Email Filtering: Body Extension</TD></TR>
 <TR><TD><A HREF="http://www.ietf.org/rfc/rfc3894.txt">RFC 3894</A></TD>

--- a/sieve/bc_emit.c
+++ b/sieve/bc_emit.c
@@ -368,10 +368,12 @@ static int bc_test_emit(int fd, int *codep, bytecode_info_t *bc)
 	int tmp;
 
 	/* drop index */
-	if(write_int(fd, bc->data[(*codep)].value) == -1)
-	    return -1;
-	wrote += sizeof(int);
-	(*codep)++;
+	if(BC_DATE == opcode) {
+		if(write_int(fd, bc->data[(*codep)].value) == -1)
+		    return -1;
+		wrote += sizeof(int);
+		(*codep)++;
+	}
 
 	/* drop zone tag */
 	tmp = bc->data[(*codep)].value;

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -459,10 +459,10 @@ static int eval_bc_test(sieve_interp_t *interp, void* m,
 	i = list_end; /* handle short-circuiting */
 	
 	break;
-    case BC_ADDRESS: /*13*/
+    case BC_ADDRESS:/*13*/
 	has_index=1;
 	/* fall through */
-    case BC_ADDRESS_PRE_INDEX: /*7*/
+    case BC_ADDRESS_PRE_INDEX:/*7*/
 	address=1;
 	/* fall through */
     case BC_ENVELOPE:/*8*/
@@ -668,7 +668,7 @@ static int eval_bc_test(sieve_interp_t *interp, void* m,
 envelope_err:
 	break;
     }
-    case BC_HEADER: /*14*/
+    case BC_HEADER:/*14*/
 	has_index=1;
 	/* fall through */
     case BC_HEADER_PRE_INDEX:/*9*/
@@ -941,12 +941,9 @@ envelope_err:
 	
 	break;
     }
-    case BC_DATE:/*15*/
-    case BC_CURRENTDATE:/*16*/
+    case BC_DATE:/*11*/
 	has_index=1;
-	/* fall through */
-    case BC_DATE_PRE_INDEX:/*11*/
-    case BC_CURRENTDATE_PRE_INDEX:/*12*/
+    case BC_CURRENTDATE:/*12*/
     {
 	char buffer[64];
 	const char **headers = NULL;
@@ -1016,9 +1013,19 @@ envelope_err:
 		/* convert index argument value to array index */
 		if (index > 0) {
 			--index;
+			if (index >= header_count) {
+				res = SIEVE_FAIL;
+				goto alldone;
+			}
+			header_count = index + 1;
 		}
-		else {
+		else if (index < 0) {
 			index += header_count;
+			if (index < 0) {
+				res = SIEVE_FAIL;
+				goto alldone;
+			}
+			header_count = index + 1;
 		}
 
 		/* check if index is out of bounds */

--- a/sieve/bc_generate.c
+++ b/sieve/bc_generate.c
@@ -464,7 +464,7 @@ static int bc_test_generate(int codep, bytecode_info_t *retval, test_t *t)
 	 *         { header-name : string } { date-part: string }
 	 *         { key-list : string list }
 	 *
-	 * BC_CURRENTDATE { i: index } { time-zone: string} { c: comparator }
+	 * BC_CURRENTDATE { time-zone: string} { c: comparator }
 	 *         { date-part: string } { key-list : string list }
 	*/
 
@@ -472,8 +472,10 @@ static int bc_test_generate(int codep, bytecode_info_t *retval, test_t *t)
 	retval->data[codep++].op = (DATE == t->type) ? BC_DATE : BC_CURRENTDATE;
 
 	/* index */
-	if(!atleast(retval,codep + 1)) return -1;
-	retval->data[codep++].value = t->u.dt.index;
+	if (DATE == t->type) {
+		if(!atleast(retval,codep + 1)) return -1;
+		retval->data[codep++].value = t->u.dt.index;
+	}
 
 	/* zone */
 	codep = bc_zone_generate(codep, retval,

--- a/sieve/bc_generate.c
+++ b/sieve/bc_generate.c
@@ -330,7 +330,7 @@ static int bc_test_generate(int codep, bytecode_info_t *retval, test_t *t)
 	if (codep == -1) return -1;
 	break;
     case HEADER:
-	/* BC_HEADER { c: comparator } { headers : string list }
+	/* BC_HEADER { i: index } { c: comparator } { headers : string list }
 	   { patterns : string list } 
 	*/
       
@@ -339,7 +339,7 @@ static int bc_test_generate(int codep, bytecode_info_t *retval, test_t *t)
       
 	/* index */
 	if(!atleast(retval,codep + 1)) return -1;
-	retval->data[codep++].value = t->u.ae.index;
+	retval->data[codep++].value = t->u.h.index;
 
 	/* comparator */
 	codep = bc_comparator_generate(codep, retval,
@@ -358,7 +358,11 @@ static int bc_test_generate(int codep, bytecode_info_t *retval, test_t *t)
 	break;
     case ADDRESS:
     case ENVELOPE:
-	/* (BC_ADDRESS | BC_ENVELOPE) {c : comparator} 
+	/* BC_ADDRESS {i : index } {c : comparator}
+	   (B_ALL | B_LOCALPART | ...) { header : string list }
+	   { pattern : string list }
+
+	   BC_ENVELOPE {c : comparator}
 	   (B_ALL | B_LOCALPART | ...) { header : string list }
 	   { pattern : string list } */
       
@@ -456,11 +460,11 @@ static int bc_test_generate(int codep, bytecode_info_t *retval, test_t *t)
 	break;
     case DATE:
     case CURRENTDATE:
-	/* BC_DATE { time-zone: string} { c: comparator }
+	/* BC_DATE { i: index } { time-zone: string} { c: comparator }
 	 *         { header-name : string } { date-part: string }
 	 *         { key-list : string list }
 	 *
-	 * BC_CURRENTDATE { time-zone: string} { c: comparator }
+	 * BC_CURRENTDATE { i: index } { time-zone: string} { c: comparator }
 	 *         { date-part: string } { key-list : string list }
 	*/
 

--- a/sieve/bytecode.h
+++ b/sieve/bytecode.h
@@ -103,8 +103,9 @@ typedef union
  * version 0x05 scripts implemented updated VACATION (:from and :handle)
  * version 0x06 scripts implemented updated VACATION (:seconds)
  * version 0x07 scripts implemented updated INCLUDE (:once and :optional)
+ * version 0x08 scripts implemented DATE and INDEX extensions
  */
-#define BYTECODE_VERSION 0x07
+#define BYTECODE_VERSION 0x08
 #define BYTECODE_MIN_VERSION 0x03 /* minimum supported version */
 #define BYTECODE_MAGIC "CyrSBytecode"
 #define BYTECODE_MAGIC_LEN 12 /* Should be multiple of 4 */

--- a/sieve/bytecode.h
+++ b/sieve/bytecode.h
@@ -155,10 +155,14 @@ enum bytecode_comps {
     BC_SIZE,
     BC_ANYOF,
     BC_ALLOF,
-    BC_ADDRESS,
+    BC_ADDRESS_PRE_INDEX,
     BC_ENVELOPE,	/* require envelope */
-    BC_HEADER,
+    BC_HEADER_PRE_INDEX,
     BC_BODY,            /* require body */
+    BC_DATE_PRE_INDEX,        /* require date */
+    BC_CURRENTDATE_PRE_INDEX, /* require date */
+    BC_ADDRESS,
+    BC_HEADER,
     BC_DATE,            /* require date */
     BC_CURRENTDATE      /* require date */
 };

--- a/sieve/bytecode.h
+++ b/sieve/bytecode.h
@@ -159,12 +159,10 @@ enum bytecode_comps {
     BC_ENVELOPE,	/* require envelope */
     BC_HEADER_PRE_INDEX,
     BC_BODY,            /* require body */
-    BC_DATE_PRE_INDEX,        /* require date */
-    BC_CURRENTDATE_PRE_INDEX, /* require date */
-    BC_ADDRESS,
-    BC_HEADER,
     BC_DATE,            /* require date */
-    BC_CURRENTDATE      /* require date */
+    BC_CURRENTDATE,     /* require date */
+    BC_ADDRESS,
+    BC_HEADER
 };
 
 /* currently one enum so as to help determine where values are being misused.

--- a/sieve/sieve.y
+++ b/sieve/sieve.y
@@ -629,6 +629,10 @@ test:     ANYOF testlist	 { $$ = new_test(ANYOF); $$->u.tl = $2; }
                                      { yyerror(parse_script, "date MUST be enabled with \"require\"");
                                        YYERROR; }
 
+                                   if ($2->index != 0) {
+                                     yyerror(parse_script, "index argument is not allowed in currentdate");
+                                     YYERROR; }
+
                                    if ($2->zonetag == ORIGINALZONE) {
                                      yyerror(parse_script, "originalzone argument is not allowed in currentdate");
                                      YYERROR; }

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -266,10 +266,10 @@ static int dump2_test(bytecode_input_t * d, int i)
 	
 	printf(")\n");
 	break;
-    case BC_ADDRESS: /*13*/
+    case BC_ADDRESS:/*13*/
 	has_index=1;
 	/*fall-through*/
-    case BC_ADDRESS_PRE_INDEX: /*7*/
+    case BC_ADDRESS_PRE_INDEX:/*7*/
 	printf("Address [");
 	index = has_index ? ntohl(d[++i].value) : 0;
 	i=printComparison(d, i+1);
@@ -311,7 +311,7 @@ static int dump2_test(bytecode_input_t * d, int i)
 	i=write_list(ntohl(d[i].len), i+1, d);
 	printf("             ]\n");
 	break;
-    case BC_HEADER: /*14*/
+    case BC_HEADER:/*14*/
 	has_index=1;
 	/*fall-through*/
     case BC_HEADER_PRE_INDEX:/*9*/
@@ -345,12 +345,9 @@ static int dump2_test(bytecode_input_t * d, int i)
 	i=write_list(ntohl(d[i].len), i+1, d);
 	printf("             ]\n");
 	break;
-    case BC_DATE:/*15*/
-    case BC_CURRENTDATE:/*16*/
+    case BC_DATE:/*11*/
 	has_index=1;
-	/*fall-through*/
-    case BC_DATE_PRE_INDEX:/*11*/
-    case BC_CURRENTDATE_PRE_INDEX:/*12*/
+    case BC_CURRENTDATE:/*12*/
 	++i; /* skip opcode */
 
 	if (BC_DATE == opcode) {
@@ -362,20 +359,17 @@ static int dump2_test(bytecode_input_t * d, int i)
 
 	/* index */
 	index = has_index ? ntohl(d[i++].value) : 0;
-	printf("              Index: %d %s\n",
-	    abs(index), index < 0 ? "[LAST]" : "");
+	if (index != 0) {
+		printf("              Index: %d %s\n",
+		    abs(index), index < 0 ? "[LAST]" : "");
+	}
 
 	/* zone tag */
 	{
-		int zone;
-		int timezone_offset;
-
 		printf("Zone-Tag: ");
-		zone = ntohl(d[i++].value);
-		switch (zone) {
+		switch (ntohl(d[i++].value)) {
 		case B_TIMEZONE:
-			timezone_offset = ntohl(d[i++].value);
-			printf("Specific timezone: offset by %d minutes.\n", timezone_offset);
+			printf("Specific timezone: offset by %d minutes.\n", ntohl(d[i++].value));
 			break;
 		case B_ORIGINALZONE:
 			printf("Original zone.\n");

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -202,6 +202,7 @@ static int dump2_test(bytecode_input_t * d, int i)
 {
     int l,x,index;
     int opcode;
+    int has_index=0;/* used to differentiate between pre and post index tests */
 
     opcode = ntohl(d[i].value);
     switch(opcode) {
@@ -265,9 +266,12 @@ static int dump2_test(bytecode_input_t * d, int i)
 	
 	printf(")\n");
 	break;
-    case BC_ADDRESS:/*7*/
+    case BC_ADDRESS: /*13*/
+	has_index=1;
+	/*fall-through*/
+    case BC_ADDRESS_PRE_INDEX: /*7*/
 	printf("Address [");
-	index = ntohl(d[++i].value);
+	index = has_index ? ntohl(d[++i].value) : 0;
 	i=printComparison(d, i+1);
 	printf("               type: ");
 	switch(ntohl(d[i++].value))
@@ -307,9 +311,12 @@ static int dump2_test(bytecode_input_t * d, int i)
 	i=write_list(ntohl(d[i].len), i+1, d);
 	printf("             ]\n");
 	break;
-    case BC_HEADER:/*9*/
+    case BC_HEADER: /*14*/
+	has_index=1;
+	/*fall-through*/
+    case BC_HEADER_PRE_INDEX:/*9*/
 	printf("Header [");
-	index = ntohl(d[++i].value);
+	index = has_index ? ntohl(d[++i].value) : 0;
 	i= printComparison(d, i+1);
 	if (index != 0) {
 		printf("              Index: %d %s\n",
@@ -338,8 +345,12 @@ static int dump2_test(bytecode_input_t * d, int i)
 	i=write_list(ntohl(d[i].len), i+1, d);
 	printf("             ]\n");
 	break;
-    case BC_DATE:/*11*/
-    case BC_CURRENTDATE:/*12*/
+    case BC_DATE:/*15*/
+    case BC_CURRENTDATE:/*16*/
+	has_index=1;
+	/*fall-through*/
+    case BC_DATE_PRE_INDEX:/*11*/
+    case BC_CURRENTDATE_PRE_INDEX:/*12*/
 	++i; /* skip opcode */
 
 	if (BC_DATE == opcode) {
@@ -350,7 +361,7 @@ static int dump2_test(bytecode_input_t * d, int i)
 	}
 
 	/* index */
-	index = ntohl(d[i++].value);
+	index = has_index ? ntohl(d[i++].value) : 0;
 	printf("              Index: %d %s\n",
 	    abs(index), index < 0 ? "[LAST]" : "");
 


### PR DESCRIPTION
There was a version of the bytecode that had the index extension but did
not update the bytecode codepoints, nor did it increment the bytecode
version number.  We use heuristics to determine if the index extension
support was included in the particular version of the bytecode.

This patch allows usage of these unnumbered versions of bytecode.